### PR TITLE
GitHub Actions workflow for a single binary creation

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,13 +20,13 @@ jobs:
           go-version: '1.20'
 
       - name: Install dependencies
-        run: go mod tidy
+        run: go mod tidy ./v2
 
       - name: Build
-        run: go build -o cook ./cmd/cook
+        run: go build -o cook ./v2/cmd/cook
 
       - name: Test
-        run: go test -v ./... -cover
+        run: go test -v ./v2/... -cover
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,12 +28,7 @@ jobs:
         run: |
           cd v2
           go build -o cook ./cmd/cook
-
-      - name: Test
-        run: |
-          cd v2
-          go test -v ./... -cover
-          
+         
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,38 @@
+name: Go
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+
+      - name: Install dependencies
+        run: go mod tidy
+
+      - name: Build
+        run: go build -o cook ./cmd/cook
+
+      - name: Test
+        run: go test -v ./... -cover
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag: ${{ github.ref }}
+          files: cook
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,10 +30,11 @@ jobs:
           go build -o cook ./cmd/cook
          
       - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
         id: create_release
         uses: softprops/action-gh-release@v1
         with:
           tag: ${{ github.ref }}
-          files: cook
+          files: v2/cook
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,9 @@ jobs:
           go-version: '1.20'
 
       - name: Install dependencies
-        run: go mod tidy ./v2
+        run: |
+          cd v2
+          go mod tidy
 
       - name: Build
         run: go build -o cook ./v2/cmd/cook

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,11 +25,15 @@ jobs:
           go mod tidy
 
       - name: Build
-        run: go build -o cook ./v2/cmd/cook
+        run: |
+          cd v2
+          go build -o cook ./cmd/cook
 
       - name: Test
-        run: go test -v ./v2/... -cover
-
+        run: |
+          cd v2
+          go test -v ./... -cover
+          
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
I have no experience using Go and the installation using the command `go install -v github.com/glitchedgitz/cook/v2/cmd/cook@latest` didn't succeed with putting `cook` in my `$PATH` therefore I created this GitHub Action that whenever a new release is pushed, a single binary including all dependencies is created for a more user friendly experience of the application.

All you have to do now is download the binary, give it execution permissions with `chmod +x cook` and execute it with `./cook`.